### PR TITLE
Remove "validateIssuerName" option for OIDC provider

### DIFF
--- a/configs/openid/prod/id-providers.json
+++ b/configs/openid/prod/id-providers.json
@@ -51,8 +51,7 @@
       "openid"
     ],
     "scopesMapping": {},
-    "claimsMapping": {},
-    "validateIssuerName": false
+    "claimsMapping": {}
   },
   "linkedin": {
     "protocol": "oauth",

--- a/configs/openid/test/id-providers.json
+++ b/configs/openid/test/id-providers.json
@@ -51,8 +51,7 @@
       "openid"
     ],
     "scopesMapping": {},
-    "claimsMapping": {},
-    "validateIssuerName": false
+    "claimsMapping": {}
   },
   "linkedin": {
     "protocol": "oauth",


### PR DESCRIPTION
No longer possible to disable issuer validation for a provider. We use issuer validation mode instead (Exact or BaseURL), which can be set per client.