### PR TITLE
Fix DigiD "sub" claims mapping

### DIFF
--- a/configs/openid/prod/id-providers.json
+++ b/configs/openid/prod/id-providers.json
@@ -129,7 +129,7 @@
       "phone": ["telephone"]
     },
     "claimsMapping": {
-      "sub": "nin"
+      "{sub}": "nin"
     },
     "tokenEndpointAuthenticationMethod": "ClientSecretPost"
   },

--- a/configs/openid/test/id-providers.json
+++ b/configs/openid/test/id-providers.json
@@ -129,7 +129,7 @@
       "phone": ["telephone"]
     },
     "claimsMapping": {
-    	"sub": "nin"
+      "{sub}": "nin"
     },
     "tokenEndpointAuthenticationMethod": "ClientSecretPost"
   },


### PR DESCRIPTION
added placeholder for sub -> nin mapping. We want to create a new "nin" claim from "sub", not directly map sub to nin.