### PR TITLE
Update MitID default scopes

### DIFF
--- a/configs/openid/test/id-providers.json
+++ b/configs/openid/test/id-providers.json
@@ -164,7 +164,8 @@
     "responseType": "code",
     "responseMode": "query",
     "defaultScopes": [
-      "openid"
+      "openid",
+      "mitid"
     ],
     "scopesMapping": {
       "ssn": ["signicat.national_id"]


### PR DESCRIPTION
The `mitid` scope is required to get MitID-specific claims (e.g `mitid.loa` and `mitid.aal`)